### PR TITLE
added support for all options as query params

### DIFF
--- a/lib/game_of_life/universe/template.ex
+++ b/lib/game_of_life/universe/template.ex
@@ -290,7 +290,7 @@ defmodule GameOfLife.Universe.Template do
       %Position{x: 17, y: 18},
       %Position{x: 18, y: 18},
       %Position{x: 19, y: 18},
-      %Position{x: 10, y: 19},
+      %Position{x: 10, y: 19}
     ]
   end
 end

--- a/lib/game_of_life_web/controllers/page_controller.ex
+++ b/lib/game_of_life_web/controllers/page_controller.ex
@@ -1,7 +1,7 @@
 defmodule GameOfLifeWeb.PageController do
   use GameOfLifeWeb, :controller
 
-   def index(conn, params) do
+  def index(conn, params) do
     live_render(conn, GameOfLifeWeb.UniverseLive, session: %{path_params: params})
   end
 end

--- a/lib/game_of_life_web/live/universe_live.ex
+++ b/lib/game_of_life_web/live/universe_live.ex
@@ -24,10 +24,8 @@ defmodule GameOfLifeWeb.UniverseLive do
     {:noreply, assign(socket, speed: String.to_integer(speed))}
   end
 
-  def handle_event("update_color", %{"color" => color}, socket) do
-    color = %Color{socket.assigns.color | red: color["red"], green: color["green"], blue: color["blue"]}
-
-    {:noreply, assign(socket, color: color)}
+  def handle_event("update_color", %{"color" => %{"red" => red, "green" => green, "blue" => blue}}, socket) do
+    {:noreply, assign(socket, color: %Color{red: red, green: green, blue: blue})}
   end
 
   def handle_event("toggle_playing", _params, socket) do

--- a/lib/game_of_life_web/live/universe_live.ex
+++ b/lib/game_of_life_web/live/universe_live.ex
@@ -78,13 +78,14 @@ defmodule GameOfLifeWeb.UniverseLive do
     socket
     |> setup_universe(opts)
     |> start_universe()
-    |> schedule_tick()
   end
 
   defp start_universe(socket) do
     universe = Universe.init(socket.assigns.template, socket.assigns.dimensions)
 
-    assign(socket, :universe, universe)
+    socket
+    |> assign(:universe, universe)
+    |> schedule_tick()
   end
 
   defp setup_universe(socket, opts) do


### PR DESCRIPTION
Example URL that initializes all options with query params

```
http://localhost:4000/?template=random&color[red]=150&color[green]=125&color[blue]=100&width=80&height=80&playing=1&speed=10
```

Also ran a `mix format` to cleanup some spacing issues